### PR TITLE
webauthn / passkey support. fixes #188

### DIFF
--- a/src/main/java/fr/cnieg/keycloak/authenticators/resetcred/ResetCredentialAttributeChooseUser.java
+++ b/src/main/java/fr/cnieg/keycloak/authenticators/resetcred/ResetCredentialAttributeChooseUser.java
@@ -1,16 +1,18 @@
 package fr.cnieg.keycloak.authenticators.resetcred;
 
-import fr.cnieg.keycloak.providers.login.attribute.authenticator.AttributeUsernamePasswordForm;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
-import org.keycloak.authentication.Authenticator;
-import org.keycloak.authentication.AuthenticatorFactory;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.authentication.authenticators.resetcred.ResetCredentialChooseUser;
+import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.FormMessage;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.services.messages.Messages;
+import org.keycloak.services.validation.Validation;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
@@ -22,23 +24,19 @@ import static fr.cnieg.keycloak.AuthenticatorUserModel.getUserModel;
 /**
  *
  */
-public class ResetCredentialAttributeChooseUser extends ResetCredentialChooseUser implements Authenticator, AuthenticatorFactory {
+public class ResetCredentialAttributeChooseUser extends ResetCredentialChooseUser {
     /**
      *
      */
     public static final String PROVIDER_ID = "reset-credentials-attr-choose-user";
     /**
-     *
+     * Attribute key used for check identity
      */
     public static final String ATTRIBUTE_KEY = "login.attribute.key";
     /**
-     *
+     * Attribute format
      */
     public static final String ATTRIBUTE_REGEX = "login.attribute.regex";
-    /**
-     *
-     */
-    public static final String ATTRIBUTE_USERNAME = "username";
 
     /**
      * noop
@@ -52,47 +50,49 @@ public class ResetCredentialAttributeChooseUser extends ResetCredentialChooseUse
      */
     @Override
     public void action(AuthenticationFlowContext context) {
-
         EventBuilder event = context.getEvent();
         MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
-        String username = formData.getFirst(ATTRIBUTE_USERNAME);
-
-        if (username != null && !username.isEmpty()) {
-            username = username.trim();
-            RealmModel realm = context.getRealm();
-
-            // Get user by username
-            UserModel user = context.getSession().users().getUserByUsername(realm, username);
-
-            // Get user by email
-            if (user == null && realm.isLoginWithEmailAllowed() && username.contains("@")) {
-                user = context.getSession().users().getUserByEmail(realm, username);
-            }
-
-            // Get user by attribute
-            if (user == null) {
-                user = this.getUserByAttribute(context, username);
-            }
-
-            context.getAuthenticationSession().setAuthNote("ATTEMPTED_USERNAME", username);
-
-            if (user == null) {
-                event.clone().detail(ATTRIBUTE_USERNAME, username).error("user_not_found");
-                context.clearUser();
-            } else if (!user.isEnabled()) {
-                event.clone().detail(ATTRIBUTE_USERNAME, username).user(user).error("user_disabled");
-                context.clearUser();
-            } else {
-                context.setUser(user);
-                context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, user.getUsername());
-            }
-
-            context.success();
-        } else {
-            event.error("username_missing");
-            Response challenge = context.form().setError("missingUsernameMessage").createPasswordReset();
+        String username = formData.getFirst("username");
+        if (username == null || username.isEmpty()) {
+            event.error(Errors.USERNAME_MISSING);
+            Response challenge = context.form()
+                    .addError(new FormMessage(Validation.FIELD_USERNAME, Messages.MISSING_USERNAME))
+                    .createPasswordReset();
             context.failureChallenge(AuthenticationFlowError.INVALID_USER, challenge);
+            return;
         }
+
+        username = username.trim();
+
+        RealmModel realm = context.getRealm();
+        UserModel user = context.getSession().users().getUserByUsername(realm, username);
+        if (user == null && realm.isLoginWithEmailAllowed() && username.contains("@")) {
+            user =  context.getSession().users().getUserByEmail(realm, username);
+        }
+        // Get user by attribute
+        if (user == null) {
+            user = this.getUserByAttribute(context, username);
+        }
+
+        context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, username);
+
+        // we don't want people guessing usernames, so if there is a problem, just continue, but don't set the user
+        // a null user will notify further executions, that this was a failure.
+        if (user == null) {
+            event.clone()
+                    .detail(Details.USERNAME, username)
+                    .error(Errors.USER_NOT_FOUND);
+            context.clearUser();
+        } else if (!user.isEnabled()) {
+            event.clone()
+                    .detail(Details.USERNAME, username)
+                    .user(user).error(Errors.USER_DISABLED);
+            context.clearUser();
+        } else {
+            context.setUser(user);
+        }
+
+        context.success();
     }
 
     private UserModel getUserByAttribute(AuthenticationFlowContext context, String userName) {
@@ -127,13 +127,13 @@ public class ResetCredentialAttributeChooseUser extends ResetCredentialChooseUse
 
     static {
         ProviderConfigProperty providerConfigProperty = new ProviderConfigProperty();
-        providerConfigProperty.setName(AttributeUsernamePasswordForm.ATTRIBUTE_KEY);
+        providerConfigProperty.setName(ResetCredentialAttributeChooseUser.ATTRIBUTE_KEY);
         providerConfigProperty.setLabel("User Attribute");
         providerConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
         providerConfigProperty.setHelpText("User attribute that can be used as an alternative identifier ");
         CONFIG_PROPERTIES.add(providerConfigProperty);
         providerConfigProperty = new ProviderConfigProperty();
-        providerConfigProperty.setName(AttributeUsernamePasswordForm.ATTRIBUTE_REGEX);
+        providerConfigProperty.setName(ResetCredentialAttributeChooseUser.ATTRIBUTE_REGEX);
         providerConfigProperty.setLabel("Attribute Regular Expression");
         providerConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
         providerConfigProperty.setHelpText("Regular expression for which the search by attribute will be performed");

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernameForm.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernameForm.java
@@ -1,0 +1,89 @@
+package fr.cnieg.keycloak.providers.login.attribute.authenticator;
+
+import java.util.Objects;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+import org.keycloak.services.messages.Messages;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+public final class AttributeUsernameForm extends AttributeUsernamePasswordForm {
+
+    public AttributeUsernameForm() {
+        super();
+    }
+
+    public AttributeUsernameForm(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        if (context.getUser() != null) {
+            // We can skip the form when user is re-authenticating. Unless current user has some IDP set, so he can re-authenticate with that IDP
+            if (!this.hasLinkedBrokers(context)) {
+                context.success();
+                return;
+            }
+        }
+        super.authenticate(context);
+    }
+
+    @Override
+    protected boolean validateForm(AuthenticationFlowContext context, MultivaluedMap<String, String> formData) {
+        return validateUser(context, formData);
+    }
+
+    @Override
+    protected Response challenge(AuthenticationFlowContext context, MultivaluedMap<String, String> formData) {
+        LoginFormsProvider forms = context.form();
+
+        if (!formData.isEmpty()) forms.setFormData(formData);
+
+        return forms.createLoginUsername();
+    }
+
+    @Override
+    protected Response createLoginForm(LoginFormsProvider form) {
+        return form.createLoginUsername();
+    }
+
+    @Override
+    protected String getDefaultChallengeMessage(AuthenticationFlowContext context) {
+        if (context.getRealm().isLoginWithEmailAllowed())
+            return Messages.INVALID_USERNAME_OR_EMAIL;
+        return Messages.INVALID_USERNAME;
+    }
+
+    /**
+     * Checks if the context user, if it has been set, is currently linked to any IDPs they could use to authenticate.
+     * If the auth session has an existing IDP in the brokered context, it is filtered out.
+     *
+     * @param context a reference to the {@link AuthenticationFlowContext}
+     * @return {@code true} if the context user has federated IDPs that can be used for authentication; {@code false} otherwise.
+     */
+    private boolean hasLinkedBrokers(AuthenticationFlowContext context) {
+        KeycloakSession session = context.getSession();
+        UserModel user = context.getUser();
+        if (user == null) {
+            return false;
+        }
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+        SerializedBrokeredIdentityContext serializedCtx = SerializedBrokeredIdentityContext.readFromAuthenticationSession(authSession, AbstractIdpAuthenticator.BROKERED_CONTEXT_NOTE);
+        final IdentityProviderModel existingIdp = (serializedCtx == null) ? null : serializedCtx.deserialize(session, authSession).getIdpConfig();
+
+        return session.users().getFederatedIdentitiesStream(session.getContext().getRealm(), user)
+                .map(fedIdentity -> session.identityProviders().getByAlias(fedIdentity.getIdentityProvider()))
+                .filter(Objects::nonNull)
+                .anyMatch(idpModel -> existingIdp == null || !Objects.equals(existingIdp.getAlias(), idpModel.getAlias()));
+
+    }
+}

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernameForm.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernameForm.java
@@ -28,11 +28,9 @@ public final class AttributeUsernameForm extends AttributeUsernamePasswordForm {
     @Override
     public void authenticate(AuthenticationFlowContext context) {
         if (context.getUser() != null) {
-            // We can skip the form when user is re-authenticating. Unless current user has some IDP set, so he can re-authenticate with that IDP
-            if (!this.hasLinkedBrokers(context)) {
-                context.success();
-                return;
-            }
+            // We can skip the form when user is re-authenticating.
+            context.success();
+            return;
         }
         super.authenticate(context);
     }
@@ -61,29 +59,5 @@ public final class AttributeUsernameForm extends AttributeUsernamePasswordForm {
         if (context.getRealm().isLoginWithEmailAllowed())
             return Messages.INVALID_USERNAME_OR_EMAIL;
         return Messages.INVALID_USERNAME;
-    }
-
-    /**
-     * Checks if the context user, if it has been set, is currently linked to any IDPs they could use to authenticate.
-     * If the auth session has an existing IDP in the brokered context, it is filtered out.
-     *
-     * @param context a reference to the {@link AuthenticationFlowContext}
-     * @return {@code true} if the context user has federated IDPs that can be used for authentication; {@code false} otherwise.
-     */
-    private boolean hasLinkedBrokers(AuthenticationFlowContext context) {
-        KeycloakSession session = context.getSession();
-        UserModel user = context.getUser();
-        if (user == null) {
-            return false;
-        }
-        AuthenticationSessionModel authSession = context.getAuthenticationSession();
-        SerializedBrokeredIdentityContext serializedCtx = SerializedBrokeredIdentityContext.readFromAuthenticationSession(authSession, AbstractIdpAuthenticator.BROKERED_CONTEXT_NOTE);
-        final IdentityProviderModel existingIdp = (serializedCtx == null) ? null : serializedCtx.deserialize(session, authSession).getIdpConfig();
-
-        return session.users().getFederatedIdentitiesStream(session.getContext().getRealm(), user)
-                .map(fedIdentity -> session.identityProviders().getByAlias(fedIdentity.getIdentityProvider()))
-                .filter(Objects::nonNull)
-                .anyMatch(idpModel -> existingIdp == null || !Objects.equals(existingIdp.getAlias(), idpModel.getAlias()));
-
     }
 }

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernameFormFactory.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernameFormFactory.java
@@ -17,15 +17,15 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.authentication.authenticators.browser.WebAuthnConditionalUIAuthenticator;
 
 /**
- * Form factory for Attribute Username Password
+ * Form factory for Attribute Username
  */
-public class AttributeUsernamePasswordFormFactory implements AuthenticatorFactory {
+public class AttributeUsernameFormFactory implements AuthenticatorFactory {
 
-    public static final String PROVIDER_ID = "attribute-username-password-form";
+    public static final String PROVIDER_ID = "attribute-username-form";
 
     @Override
     public Authenticator create(KeycloakSession session) {
-        return new AttributeUsernamePasswordForm(session);
+        return new AttributeUsernameForm(session);
     }
 
     @Override
@@ -76,12 +76,12 @@ public class AttributeUsernamePasswordFormFactory implements AuthenticatorFactor
 
     @Override
     public String getDisplayType() {
-        return "Attribute Username Password Form";
+        return "Attribute Username Form";
     }
 
     @Override
     public String getHelpText() {
-        return "Validates a username or attribute and password from login form.";
+        return "Selects a user from his username or attribute.";
     }
 
     @Override

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordForm.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordForm.java
@@ -10,6 +10,7 @@ import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAu
 import org.keycloak.authentication.authenticators.browser.UsernamePasswordForm;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.UserModel;
@@ -40,6 +41,14 @@ public class AttributeUsernamePasswordForm extends UsernamePasswordForm implemen
      * Authorize any password
      */
     public static final String AUTHORIZE_ANY_PASSWORD = "authorize.any.password";
+
+    public AttributeUsernamePasswordForm() {
+        super();
+    }
+
+    public AttributeUsernamePasswordForm(KeycloakSession session) {
+        super(session);
+    }
 
     private UserModel getUserByAttribute(AuthenticationFlowContext context, String userName) {
         return getUserModel(context, userName, ATTRIBUTE_KEY, ATTRIBUTE_REGEX);

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordForm.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordForm.java
@@ -2,16 +2,13 @@ package fr.cnieg.keycloak.providers.login.attribute.authenticator;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
-import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
-import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.authentication.authenticators.browser.UsernamePasswordForm;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -20,15 +17,12 @@ import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
 
 import static fr.cnieg.keycloak.AuthenticatorUserModel.getUserModel;
+import static org.keycloak.services.validation.Validation.FIELD_USERNAME;
 
 /**
  * Attribute username password form
  */
-public class AttributeUsernamePasswordForm extends UsernamePasswordForm implements Authenticator {
-    /**
-     * Logger used by class
-     */
-    protected static final Logger logger = Logger.getLogger(AttributeUsernamePasswordForm.class);
+public class AttributeUsernamePasswordForm extends UsernamePasswordForm {
     /**
      * Attribute key used for check identity
      */
@@ -37,10 +31,6 @@ public class AttributeUsernamePasswordForm extends UsernamePasswordForm implemen
      * Attribute format
      */
     public static final String ATTRIBUTE_REGEX = "login.attribute.regex";
-    /**
-     * Authorize any password
-     */
-    public static final String AUTHORIZE_ANY_PASSWORD = "authorize.any.password";
 
     public AttributeUsernamePasswordForm() {
         super();
@@ -61,23 +51,9 @@ public class AttributeUsernamePasswordForm extends UsernamePasswordForm implemen
      */
     @Override
     public boolean validateUserAndPassword(AuthenticationFlowContext context, MultivaluedMap<String, String> inputData) {
-        logger.debug("validateUserAndPassword()");
-        context.clearUser();
-        UserModel user = getUserOrAttribute(context, inputData);
-        return user != null &&
-                validateUser(context, user, inputData) &&
-                (validateAnyPassword(context) || validatePassword(context, user, inputData, true));
-    }
-
-    private boolean validateAnyPassword(AuthenticationFlowContext context) {
-        AuthenticatorConfigModel config = context.getAuthenticatorConfig();
-        if (config != null) {
-            if (Boolean.parseBoolean(config.getConfig().get(AUTHORIZE_ANY_PASSWORD))) {
-                logger.warn("Password not validated, use this configuration only for tests purpose");
-                return true;
-            }
-        }
-        return false;
+        UserModel user = getAttributeUser(context, inputData);
+        boolean shouldClearUserFromCtxAfterBadPassword = !isUserAlreadySetBeforeUsernamePasswordAuth(context);
+        return user != null && validatePassword(context, user, inputData, shouldClearUserFromCtxAfterBadPassword) && validateUser(context, user, inputData);
     }
 
     /**
@@ -87,18 +63,16 @@ public class AttributeUsernamePasswordForm extends UsernamePasswordForm implemen
      */
     @Override
     public boolean validateUser(AuthenticationFlowContext context, MultivaluedMap<String, String> inputData) {
-        logger.debug("validateUser()");
-        context.clearUser();
-        UserModel user = getUserOrAttribute(context, inputData);
+        UserModel user = getAttributeUser(context, inputData);
         return user != null && validateUser(context, user, inputData);
     }
 
-    private boolean validateUser(AuthenticationFlowContext context, UserModel user, MultivaluedMap<String, String> inputData) {
+    protected boolean validateUser(AuthenticationFlowContext context, UserModel user, MultivaluedMap<String, String> inputData) {
         if (!enabledUser(context, user)) {
             return false;
         }
         String rememberMe = inputData.getFirst("rememberMe");
-        boolean remember = rememberMe != null && rememberMe.equalsIgnoreCase("on");
+        boolean remember = context.getRealm().isRememberMe() && rememberMe != null && rememberMe.equalsIgnoreCase("on");
         if (remember) {
             context.getAuthenticationSession().setAuthNote(Details.REMEMBER_ME, "true");
             context.getEvent().detail(Details.REMEMBER_ME, "true");
@@ -109,27 +83,39 @@ public class AttributeUsernamePasswordForm extends UsernamePasswordForm implemen
         return true;
     }
 
-    private UserModel getUserOrAttribute(AuthenticationFlowContext context, MultivaluedMap<String, String> inputData) {
+    protected UserModel getAttributeUser(AuthenticationFlowContext context, MultivaluedMap<String, String> inputData) {
+        if (isUserAlreadySetBeforeUsernamePasswordAuth(context)) {
+            // Get user from the authentication context in case he was already set before this authenticator
+            UserModel user = context.getUser();
+            testInvalidUser(context, user);
+            return user;
+        } else {
+            // Normal login. In this case this authenticator is supposed to establish identity of the user from the provided username
+            context.clearUser();
+            return getAttributeUserFromForm(context, inputData);
+        }
+    }
 
-        String userName = inputData.getFirst(AuthenticationManager.FORM_USERNAME);
-        if (userName == null) {
+    protected UserModel getAttributeUserFromForm(AuthenticationFlowContext context, MultivaluedMap<String, String> inputData) {
+        String username = inputData.getFirst(AuthenticationManager.FORM_USERNAME);
+        if (username == null || username.isEmpty()) {
             context.getEvent().error(Errors.USER_NOT_FOUND);
-            Response challengeResponse = challenge(context, getDefaultChallengeMessage(context));
+            Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
             context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
             return null;
         }
 
         // remove leading and trailing whitespace
-        userName = userName.trim();
+        username = username.trim();
 
-        context.getEvent().detail(Details.USERNAME, userName);
-        context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, userName);
+        context.getEvent().detail(Details.USERNAME, username);
+        context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, username);
 
-        UserModel user;
+        UserModel user = null;
         try {
-            user = KeycloakModelUtils.findUserByNameOrEmail(context.getSession(), context.getRealm(), userName);
+            user = KeycloakModelUtils.findUserByNameOrEmail(context.getSession(), context.getRealm(), username);
             if (user == null) {
-                user = this.getUserByAttribute(context, userName);
+                user = this.getUserByAttribute(context, username);
                 if(user != null) {
                     context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, user.getUsername());
                 }
@@ -143,7 +129,7 @@ public class AttributeUsernamePasswordForm extends UsernamePasswordForm implemen
             } else {
                 setDuplicateUserChallenge(context, Errors.USERNAME_IN_USE, Messages.USERNAME_EXISTS, AuthenticationFlowError.INVALID_USER);
             }
-            return null;
+            return user;
         }
 
         testInvalidUser(context, user);

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordFormFactory.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordFormFactory.java
@@ -7,10 +7,14 @@ import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.authentication.authenticators.browser.WebAuthnConditionalUIAuthenticator;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Form factory for Attribute Username Password
@@ -21,10 +25,6 @@ public class AttributeUsernamePasswordFormFactory implements AuthenticatorFactor
      * Provider Id
      */
     public static final String PROVIDER_ID = "attribute-username-password-form";
-    /**
-     * Singleton instance
-     */
-    public static final AttributeUsernamePasswordForm SINGLETON = new AttributeUsernamePasswordForm();
 
     /**
      * @param session keycloak user session
@@ -32,7 +32,7 @@ public class AttributeUsernamePasswordFormFactory implements AuthenticatorFactor
      */
     @Override
     public Authenticator create(KeycloakSession session) {
-        return SINGLETON;
+        return new AttributeUsernamePasswordForm(session);
     }
 
     /**
@@ -73,6 +73,13 @@ public class AttributeUsernamePasswordFormFactory implements AuthenticatorFactor
     @Override
     public String getReferenceCategory() {
         return PasswordCredentialModel.TYPE;
+    }
+
+    @Override
+    public Set<String> getOptionalReferenceCategories(KeycloakSession session) {
+        return WebAuthnConditionalUIAuthenticator.isPasskeysEnabled(session)
+                ? Collections.singleton(WebAuthnCredentialModel.TYPE_PASSWORDLESS)
+                : AuthenticatorFactory.super.getOptionalReferenceCategories(session);
     }
 
     /**

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordOptionalForm.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordOptionalForm.java
@@ -1,0 +1,137 @@
+package fr.cnieg.keycloak.providers.login.attribute.authenticator;
+
+import org.jboss.logging.Logger;
+import java.util.Objects;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
+import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserCredentialModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.FormMessage;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.messages.Messages;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.events.Errors;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import static org.keycloak.services.validation.Validation.FIELD_PASSWORD;
+
+public final class AttributeUsernamePasswordOptionalForm extends AttributeUsernamePasswordForm {
+
+    private static final Logger logger = Logger.getLogger(AttributeUsernamePasswordOptionalForm.class);
+
+
+    public AttributeUsernamePasswordOptionalForm() {
+        super();
+    }
+
+    public AttributeUsernamePasswordOptionalForm(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        if (context.getUser() != null) {
+            // We can skip the form when user is re-authenticating.
+            context.success();
+            return;
+        }
+        super.authenticate(context);
+    }
+
+    @Override
+    public boolean validatePassword(AuthenticationFlowContext context, UserModel user, MultivaluedMap<String, String> inputData, boolean clearUser) {
+        String password = inputData.getFirst(CredentialRepresentation.PASSWORD);
+        if (password == null || password.isEmpty()) {
+            return true;
+        }
+
+        if (isDisabledByBruteForce(context, user)) {
+            return false;
+        }
+
+        if (user.credentialManager().isValid(UserCredentialModel.password(password))) {
+            context.getAuthenticationSession().setAuthNote(AuthenticationManager.PASSWORD_VALIDATED, "true");
+            return true;
+        }
+
+        return badPasswordHandler(context, user, clearUser);
+    }
+
+    @Override
+    protected Response challenge(AuthenticationFlowContext context, MultivaluedMap<String, String> formData) {
+        LoginFormsProvider forms = context.form();
+
+        if (!formData.isEmpty()) forms.setFormData(formData);
+
+        return forms.createLoginUsername();
+    }
+
+    @Override
+    protected Response challenge(AuthenticationFlowContext context, String error, String field) {
+        if (isConditionalPasskeysEnabled(context.getUser())) {
+            // setup webauthn data when possible
+            webauthnAuth.fillContextForm(context);
+        }
+
+        LoginFormsProvider form = context.form()
+                .setExecution(context.getExecution().getId());
+
+        AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
+
+        if (Boolean.parseBoolean(authenticationSession.getAuthNote(USERNAME_HIDDEN))) {
+            // if username is hidden, shown errors in the password field instead
+            field = FIELD_PASSWORD;
+        }
+
+        if (error != null) {
+            if (field != null) {
+                form.addError(new FormMessage(field, error));
+            } else {
+                form.setError(error);
+            }
+        }
+
+        if (context.getError() == AuthenticationFlowError.INVALID_CREDENTIALS) {
+            return form.createLoginUsernamePassword();
+        }
+
+        return createLoginForm(form);
+    }
+
+    @Override
+    protected Response createLoginForm(LoginFormsProvider form) {
+        return form.createLoginUsername();
+    }
+
+    @Override
+    protected String getDefaultChallengeMessage(AuthenticationFlowContext context) {
+        if (context.getRealm().isLoginWithEmailAllowed())
+            return Messages.INVALID_USERNAME_OR_EMAIL;
+        return Messages.INVALID_USERNAME;
+    }
+
+    // Set up AuthenticationFlowContext error.
+    private boolean badPasswordHandler(AuthenticationFlowContext context, UserModel user, boolean clearUser) {
+        context.getEvent().user(user);
+        context.getEvent().error(Errors.INVALID_USER_CREDENTIALS);
+
+        AuthenticatorUtils.setupReauthenticationInUsernamePasswordFormError(context);
+
+        Response challengeResponse = challenge(context, Messages.INVALID_PASSWORD, FIELD_PASSWORD);
+        context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
+
+        if (clearUser) {
+            context.clearUser();
+        }
+        return true;
+    }
+}

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordOptionalFormFactory.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/AttributeUsernamePasswordOptionalFormFactory.java
@@ -1,0 +1,114 @@
+package fr.cnieg.keycloak.providers.login.attribute.authenticator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.models.credential.WebAuthnCredentialModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.authentication.authenticators.browser.WebAuthnConditionalUIAuthenticator;
+
+/**
+ * Form factory for Attribute Username Password (Optional/Hidden for password managers)
+ */
+public class AttributeUsernamePasswordOptionalFormFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "attribute-username-password-opt-form";
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return new AttributeUsernamePasswordOptionalForm(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return PasswordCredentialModel.TYPE;
+    }
+
+    @Override
+    public Set<String> getOptionalReferenceCategories(KeycloakSession session) {
+        return WebAuthnConditionalUIAuthenticator.isPasskeysEnabled(session)
+                ? Collections.singleton(WebAuthnCredentialModel.TYPE_PASSWORDLESS)
+                : AuthenticatorFactory.super.getOptionalReferenceCategories(session);
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    public static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+            AuthenticationExecutionModel.Requirement.REQUIRED
+    };
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Attribute Username Password-Optional Form";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Validates a username or attribute and optional password from login form.";
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = new ArrayList<>();
+
+    static {
+        ProviderConfigProperty providerConfigProperty = new ProviderConfigProperty();
+        providerConfigProperty.setName(AttributeUsernamePasswordForm.ATTRIBUTE_KEY);
+        providerConfigProperty.setLabel("User Attribute");
+        providerConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
+        providerConfigProperty.setHelpText("User attribute that can be used as an alternative identifier ");
+        CONFIG_PROPERTIES.add(providerConfigProperty);
+        providerConfigProperty = new ProviderConfigProperty();
+        providerConfigProperty.setName(AttributeUsernamePasswordForm.ATTRIBUTE_REGEX);
+        providerConfigProperty.setLabel("Attribute Regular Expression");
+        providerConfigProperty.setType(ProviderConfigProperty.STRING_TYPE);
+        providerConfigProperty.setHelpText("Regular expression for which the search by attribute will be performed");
+        providerConfigProperty.setDefaultValue(".*");
+        CONFIG_PROPERTIES.add(providerConfigProperty);
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return CONFIG_PROPERTIES;
+    }
+}

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/PasswordOnceForm.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/PasswordOnceForm.java
@@ -1,0 +1,24 @@
+package fr.cnieg.keycloak.providers.login.attribute.authenticator;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.browser.PasswordForm;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.managers.AuthenticationManager;
+
+public class PasswordOnceForm extends PasswordForm {
+
+    public PasswordOnceForm(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        String passwordValidated = context.getAuthenticationSession().getAuthNote(AuthenticationManager.PASSWORD_VALIDATED);
+        if (Boolean.parseBoolean(passwordValidated)) {
+            context.success();
+            return;
+        }
+
+        super.authenticate(context);
+    }
+}

--- a/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/PasswordOnceFormFactory.java
+++ b/src/main/java/fr/cnieg/keycloak/providers/login/attribute/authenticator/PasswordOnceFormFactory.java
@@ -1,0 +1,82 @@
+package fr.cnieg.keycloak.providers.login.attribute.authenticator;
+
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class PasswordOnceFormFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "auth-password-once-form";
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return new PasswordOnceForm(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return PasswordCredentialModel.TYPE;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Password Once Form";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Validates a password from login form unless already validated.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return null;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+}

--- a/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,3 +1,5 @@
 fr.cnieg.keycloak.providers.login.attribute.authenticator.AttributeUsernamePasswordFormFactory
 fr.cnieg.keycloak.providers.login.attribute.authenticator.AttributeUsernameFormFactory
+fr.cnieg.keycloak.providers.login.attribute.authenticator.AttributeUsernamePasswordOptionalFormFactory
+fr.cnieg.keycloak.providers.login.attribute.authenticator.PasswordOnceFormFactory
 fr.cnieg.keycloak.authenticators.resetcred.ResetCredentialAttributeChooseUser

--- a/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,2 +1,3 @@
 fr.cnieg.keycloak.providers.login.attribute.authenticator.AttributeUsernamePasswordFormFactory
+fr.cnieg.keycloak.providers.login.attribute.authenticator.AttributeUsernameFormFactory
 fr.cnieg.keycloak.authenticators.resetcred.ResetCredentialAttributeChooseUser


### PR DESCRIPTION
Properly initialize the extended UsernamePasswordForm with `super()` and move away from singleton pattern.

This way passkeys work for me.